### PR TITLE
Add an option for building SDL3 from source without X11

### DIFF
--- a/sdl3-sys/Cargo.toml
+++ b/sdl3-sys/Cargo.toml
@@ -27,6 +27,10 @@ link-static = []
 # Link SDL as a mac framework. The link-static feature has no effect if this is enabled.
 link-framework = []
 
+# When building from source, use the `SDL_UNIX_CONSOLE_BUILD` flag to disable the X11 dependency
+# and build a console-only version of SDL. This has no effect when not building from source.
+console-build = []
+
 # Use pkg-config to get link flags for SDL. Only used when not building from source.
 # This has no effect if the link-framework feature is enabled.
 use-pkg-config = ["dep:pkg-config"]

--- a/sdl3-sys/Cargo.toml
+++ b/sdl3-sys/Cargo.toml
@@ -29,7 +29,7 @@ link-framework = []
 
 # When building from source, use the `SDL_UNIX_CONSOLE_BUILD` flag to disable the X11 dependency
 # and build a console-only version of SDL. This has no effect when not building from source.
-console-build = []
+sdl-unix-console-build = []
 
 # Use pkg-config to get link flags for SDL. Only used when not building from source.
 # This has no effect if the link-framework feature is enabled.

--- a/sdl3-sys/build.rs
+++ b/sdl3-sys/build.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             let mut config = Config::new(sdl3_src::SOURCE_DIR);
             config.define("SDL_REVISION", sdl3_src::REVISION);
-            if cfg!(feature = "console-build") {
+            if cfg!(feature = "sdl-unix-console-build") {
                 config.define("SDL_UNIX_CONSOLE_BUILD", "ON");
             }
             if cfg!(feature = "link-framework") {

--- a/sdl3-sys/build.rs
+++ b/sdl3-sys/build.rs
@@ -39,6 +39,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             let mut config = Config::new(sdl3_src::SOURCE_DIR);
             config.define("SDL_REVISION", sdl3_src::REVISION);
+            if cfg!(feature = "console-build") {
+                config.define("SDL_UNIX_CONSOLE_BUILD", "ON");
+            }
             if cfg!(feature = "link-framework") {
                 config.define("SDL_FRAMEWORK", "ON");
             } else if cfg!(feature = "link-static") {


### PR DESCRIPTION
My project uses SDL3 on an embedded platform without X11, so I came into this error. This fix seems to work locally.