### PR TITLE
allow linking to macOS frameworks for sdl3-image-sys and sdl3-ttf-sys

### DIFF
--- a/sdl3-image-sys/Cargo.toml
+++ b/sdl3-image-sys/Cargo.toml
@@ -26,6 +26,9 @@ build-static-vendored = ["build-from-source-static", "sdlimage-vendored"]
 # Link SDL3_image as a static library. The default is to link a shared/dynamic library.
 link-static = []
 
+# Link SDL3_image as a mac framework. The link-static feature has no effect if this is enabled.
+link-framework = []
+
 # Use pkg-config to get link flags for SDL3_image. Only used when not building from source.
 # This has no effect if the link-framework feature is enabled.
 use-pkg-config = ["dep:pkg-config"]

--- a/sdl3-image-sys/build.rs
+++ b/sdl3-image-sys/build.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "build-from-source")]
 const SOURCE_DIR: &str = sdl3_image_src::SOURCE_DIR;
 
-const LINK_FRAMEWORK: bool = false;
+const LINK_FRAMEWORK: bool = cfg!(feature = "link-framework");
 
 include!("build-common.rs");
 

--- a/sdl3-ttf-sys/Cargo.toml
+++ b/sdl3-ttf-sys/Cargo.toml
@@ -27,6 +27,9 @@ build-static-vendored = ["build-from-source-static", "sdlttf-vendored"]
 # Link SDL3_ttf as a static library. The default is to link a shared/dynamic library.
 link-static = []
 
+# Link SDL3_ttf as a mac framework. The link-static feature has no effect if this is enabled.
+link-framework = []
+
 # Use pkg-config to get link flags for SDL3_ttf. Only used when not building from source.
 # This has no effect if the link-framework feature is enabled.
 use-pkg-config = ["dep:pkg-config"]

--- a/sdl3-ttf-sys/build.rs
+++ b/sdl3-ttf-sys/build.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "build-from-source")]
 const SOURCE_DIR: &str = sdl3_ttf_src::SOURCE_DIR;
 
-const LINK_FRAMEWORK: bool = false;
+const LINK_FRAMEWORK: bool = cfg!(feature = "link-framework");
 
 include!("build-common.rs");
 


### PR DESCRIPTION
SDL_image and SDL_ttf are both now available as macOS frameworks (see https://github.com/libsdl-org/SDL_image/releases/tag/release-3.2.4 as an example)

link-framework should therefore be exposed on all -sys crates and the build.rs should all allow linking frameworks